### PR TITLE
Disabled functionality that adds SERVERID header

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@rightscale.com'
 license          'Apache 2.0'
 description      'Application cookbook to set up HAProxy on a RightScale environment'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.2.1'
+version          '1.2.2'
 
 depends 'marker', '~> 1.0.1'
 depends 'haproxy', '~> 1.6.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -133,7 +133,7 @@ if node['haproxy']['httpchk']
 end
 
 if node['rs-haproxy']['session_stickiness']
-  node.default['haproxy']['config']['defaults']['cookie'] = 'SERVERID insert indirect nocache'
+  node.default['haproxy']['config']['defaults']['cookie'] = 'SERVERID nocache'
 end
 
 # Confirm that rsyslog is installed.


### PR DESCRIPTION
Disabled functionality that adds SERVERID to response HEADER.  This will prevent AEM from caching and including that in subsequent requests which is causing an uneven distribution of load on the Tomcat ServerArrays